### PR TITLE
Fix overlay checkmark via CSS

### DIFF
--- a/app/css/checkmark-fix.css
+++ b/app/css/checkmark-fix.css
@@ -1,0 +1,5 @@
+/* Temporary fix to remove blocking checkmark/play overlays */
+button[aria-label="Watch the video"],
+svg[viewBox="0 0 88 88"] {
+  display: none !important;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import './css/style.css'
+import './css/checkmark-fix.css'
 
 import { Inter, Playfair_Display } from 'next/font/google'
 import AOSInit from '@/components/aos-init'


### PR DESCRIPTION
## Summary
- hide problematic video overlay icons with CSS

## Testing
- `npm run lint` *(fails: "How would you like to configure ESLint")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872cf76c5788328a6f69c46599094de