### PR TITLE
Add Storyblok history components

### DIFF
--- a/components/storyblok/HistorySection.tsx
+++ b/components/storyblok/HistorySection.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { storyblokEditable, StoryblokComponent } from '@/lib/storyblok'
+import type { SbBlokData } from '@storyblok/react'
+
+export interface HistorySectionStoryblok {
+  content: any
+  station_cards: SbBlokData[]
+  _uid: string
+  component: 'history_section'
+}
+
+interface HistorySectionProps {
+  blok: HistorySectionStoryblok
+}
+
+function richTextToPlainText(richText: any): string {
+  if (!richText) return ''
+  if (typeof richText === 'string') return richText
+  if (richText.content) {
+    return richText.content
+      .map((item: any) => {
+        if (item.type === 'paragraph' && item.content) {
+          return item.content.map((t: any) => t.text || '').join('')
+        }
+        return ''
+      })
+      .join('\n')
+  }
+  return ''
+}
+
+export default function HistorySection({ blok }: HistorySectionProps) {
+  return (
+    <section {...storyblokEditable(blok)} className="py-16 bg-white">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+        <div className="grid md:grid-cols-3 gap-8">
+          <div className="md:col-span-1 prose max-w-none">
+            <p>{richTextToPlainText(blok.content)}</p>
+          </div>
+          <div className="md:col-span-2 grid md:grid-cols-2 gap-6">
+            {blok.station_cards?.map((card) => (
+              <StoryblokComponent blok={card} key={card._uid} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/components/storyblok/StationCard.tsx
+++ b/components/storyblok/StationCard.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { storyblokEditable } from '@/lib/storyblok'
+import Image from 'next/image'
+import { useState } from 'react'
+
+export interface StationCardStoryblok {
+  title: string
+  content: any
+  image?: {
+    filename: string
+    alt?: string
+  }
+  _uid: string
+  component: 'station_card'
+}
+
+interface StationCardProps {
+  blok: StationCardStoryblok
+}
+
+function richTextToPlainText(richText: any): string {
+  if (!richText) return ''
+  if (typeof richText === 'string') return richText
+  if (richText.content) {
+    return richText.content
+      .map((item: any) => {
+        if (item.type === 'paragraph' && item.content) {
+          return item.content.map((t: any) => t.text || '').join('')
+        }
+        return ''
+      })
+      .join(' ')
+  }
+  return ''
+}
+
+function truncateToWords(text: string, maxWords: number = 100): string {
+  const words = text.split(/\s+/)
+  if (words.length <= maxWords) return text
+  return words.slice(0, maxWords).join(' ') + '...'
+}
+
+export default function StationCard({ blok }: StationCardProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const plainText = richTextToPlainText(blok.content)
+  const truncated = truncateToWords(plainText, 100)
+
+  return (
+    <div
+      {...storyblokEditable(blok)}
+      className="bg-white rounded-lg shadow-md border border-gray-200 p-6 flex flex-col"
+    >
+      {blok.image && (
+        <Image
+          src={blok.image.filename}
+          alt={blok.image.alt || blok.title}
+          width={400}
+          height={300}
+          className="w-full h-48 object-cover rounded mb-4"
+        />
+      )}
+      <h3 className="text-xl font-semibold text-gray-900 mb-3">{blok.title}</h3>
+      <p className="text-gray-700 mb-4 whitespace-pre-line">
+        {expanded ? plainText : truncated}
+      </p>
+      {plainText.split(/\s+/).length > 100 && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="self-start text-blue-600 hover:text-blue-800 font-medium"
+        >
+          {expanded ? 'Show Less' : 'Read More'}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/create-storyblok-content.js
+++ b/create-storyblok-content.js
@@ -243,6 +243,28 @@ const contentTypes = [
     }
   },
   {
+    name: 'station_card',
+    display_name: 'Station Card',
+    schema: {
+      title: { type: 'text', display_name: 'Title', required: true },
+      content: { type: 'richtext', display_name: 'Content' },
+      image: { type: 'asset', display_name: 'Image' }
+    }
+  },
+  {
+    name: 'history_section',
+    display_name: 'History Section',
+    schema: {
+      content: { type: 'richtext', display_name: 'Content' },
+      station_cards: {
+        type: 'bloks',
+        restrict_components: true,
+        component_whitelist: ['station_card'],
+        display_name: 'Station Cards'
+      }
+    }
+  },
+  {
     name: 'navigation',
     display_name: 'Navigation',
     schema: {
@@ -348,6 +370,27 @@ const stories = [
         layout: 'single_column',
         background_color: 'white'
       }]
+    }
+  },
+  {
+    name: "history",
+    slug: "history",
+    content: {
+      component: "page",
+      title: "Broadcast History",
+      slug: "history",
+      meta_description: "Historical overview of Idaho radio stations",
+      seo_title: "Idaho Broadcasting History",
+      content_sections: [
+        {
+          component: "history_section",
+          content: {
+            type: "doc",
+            content: [{ type: "paragraph", content: [{ type: "text", text: "Historical notes go here." }] }]
+          },
+          station_cards: []
+        }
+      ]
     }
   },
   {

--- a/lib/storyblok.ts
+++ b/lib/storyblok.ts
@@ -9,6 +9,8 @@ import ContentSection from '@/components/storyblok/ContentSection'
 import Features from '@/components/storyblok/Features'
 import FeatureItem from '@/components/storyblok/FeatureItem'
 import CTA from '@/components/storyblok/CTA'
+import StationCard from '@/components/storyblok/StationCard'
+import HistorySection from '@/components/storyblok/HistorySection'
 
 storyblokInit({
   accessToken: process.env.STORYBLOK_ACCESS_TOKEN,
@@ -24,6 +26,8 @@ storyblokInit({
     'features': Features,
     'feature_item': FeatureItem,
     'cta': CTA,
+    'station_card': StationCard,
+    'history_section': HistorySection,
   },
 })
 


### PR DESCRIPTION
## Summary
- add new Storyblok components for station card and history section
- register the new components in `storyblok.ts`
- scaffold history story in Storyblok setup script

## Testing
- `npm install`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6876a13030b88328a2a44c725d448493